### PR TITLE
fix "result type Float can't be cast to the desired output type Long" error

### DIFF
--- a/train.py
+++ b/train.py
@@ -388,10 +388,11 @@ class WeightEMA(object):
     def step(self):
         one_minus_alpha = 1.0 - self.alpha
         for param, ema_param in zip(self.params, self.ema_params):
-            ema_param.mul_(self.alpha)
-            ema_param.add_(param * one_minus_alpha)
-            # customized weight decay
-            param.mul_(1 - self.wd)
+            if ema_param.dtype==torch.float32:
+                ema_param.mul_(self.alpha)
+                ema_param.add_(param * one_minus_alpha)
+                # customized weight decay
+                param.mul_(1 - self.wd)
 
 def interleave_offsets(batch, nu):
     groups = [batch // (nu + 1)] * (nu + 1)


### PR DESCRIPTION
see https://github.com/YU1ut/MixMatch-pytorch/issues/27

h/t to @afterall204168 for the proposed fix
