### PR TITLE
making compatible with PyTorch 1.5.1

### DIFF
--- a/train.py
+++ b/train.py
@@ -217,7 +217,7 @@ def train(labeled_trainloader, unlabeled_trainloader, model, optimizer, ema_opti
         batch_size = inputs_x.size(0)
 
         # Transform label to one-hot
-        targets_x = torch.zeros(batch_size, 10).scatter_(1, targets_x.view(-1,1), 1)
+        targets_x = torch.zeros(batch_size, 10).scatter_(1, targets_x.view(-1,1).long(), 1)
 
         if use_cuda:
             inputs_x, targets_x = inputs_x.cuda(), targets_x.cuda(non_blocking=True)


### PR DESCRIPTION
fix `Expected object of scalar type Long but got scalar type Int for argument #3 'index' in call to _th_scatter_`


To fully working with PyTorch 1.5.1, One should fix another bug #27 