### PR TITLE
Update to work with pytorch 1.11.0

### DIFF
--- a/train.py
+++ b/train.py
@@ -320,7 +320,8 @@ def validate(valloader, model, criterion, epoch, use_cuda, mode):
             data_time.update(time.time() - end)
 
             if use_cuda:
-                inputs, targets = inputs.cuda(), targets.cuda(non_blocking=True)
+                inputs = inputs.cuda()
+                targets = targets.type(torch.LongTensor).cuda(non_blocking=True)
             # compute output
             outputs = model(inputs)
             loss = criterion(outputs, targets)

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -13,6 +13,6 @@ def accuracy(output, target, topk=(1,)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].reshape(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res


### PR DESCRIPTION
Previously running this on pytorch 1.11.0 failed with `RuntimeError: "nll_loss_forward_reduce_cuda_kernel_2d_index" not implemented for 'Int'`. After converting training labels to long (which is not for some reason a requirement), I ran in the next error `RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.`. I fixed both and the accuracy/loss is computed normally. 